### PR TITLE
Task 7

### DIFF
--- a/lib/aws-shop-services-stack.ts
+++ b/lib/aws-shop-services-stack.ts
@@ -10,9 +10,7 @@ import 'dotenv/config'
 export class AwsShopServicesStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-
-
-    const gateway = new GatewayStack(this, 'GatewayService')
+    const gateway = new GatewayStack(this, 'GatewayService', process.env.soullnik as string)
     const sqs = new SqsStack(this, 'SqsService')
     const sns = new SnsStack(this, 'SnsService', process.env.SNS_EMAIL as string)
     new ProductsServiceStack(this, 'ProductsService', gateway, sqs.catalogItemsQueue, sns.createProductTopic)

--- a/lib/aws-shop-services-stack.ts
+++ b/lib/aws-shop-services-stack.ts
@@ -15,7 +15,7 @@ export class AwsShopServicesStack extends cdk.Stack {
     const gateway = new GatewayStack(this, 'GatewayService')
     const sqs = new SqsStack(this, 'SqsService')
     const sns = new SnsStack(this, 'SnsService', process.env.SNS_EMAIL as string)
-    new ProductsServiceStack(this, 'ProductsService', gateway.api, sqs.catalogItemsQueue, sns.createProductTopic)
-    new ImportServiceStack(this, 'ImportService', gateway.api, sqs.catalogItemsQueue)
+    new ProductsServiceStack(this, 'ProductsService', gateway, sqs.catalogItemsQueue, sns.createProductTopic)
+    new ImportServiceStack(this, 'ImportService', gateway, sqs.catalogItemsQueue)
   }
 }

--- a/lib/gateway-shop-stack.ts
+++ b/lib/gateway-shop-stack.ts
@@ -1,10 +1,22 @@
 import { Construct } from "constructs";
-import { RestApi, Cors } from "aws-cdk-lib/aws-apigateway";
+import { RestApi, Cors, TokenAuthorizer } from "aws-cdk-lib/aws-apigateway";
+import { AuthorizationService } from "../src/authorization";
+import { createLambda } from "../src/utils/createLambda";
 
 export class GatewayStack extends Construct {
     public api: RestApi
+    public authorizer: TokenAuthorizer
     constructor(scope: Construct, id: string) {
         super(scope, id);
+        const authFunc = createLambda(this, {
+            name: 'AuthorizationHandler',
+            handlerPath: AuthorizationService.basicAuthorizer(),
+        })
+
+        this.authorizer = new TokenAuthorizer(this, 'reques-authorizer', {
+            handler: authFunc,
+            identitySource: 'method.request.header.AuthorizeToken'
+        })
 
         this.api = new RestApi(this, 'products-api', {
             description: 'import-api gateway',

--- a/lib/gateway-shop-stack.ts
+++ b/lib/gateway-shop-stack.ts
@@ -1,16 +1,18 @@
 import { Construct } from "constructs";
-import { RestApi, Cors, TokenAuthorizer } from "aws-cdk-lib/aws-apigateway";
+import { RestApi, Cors, TokenAuthorizer, ResponseType } from "aws-cdk-lib/aws-apigateway";
 import { AuthorizationService } from "../src/authorization";
 import { createLambda } from "../src/utils/createLambda";
 
 export class GatewayStack extends Construct {
     public api: RestApi
     public authorizer: TokenAuthorizer
-    constructor(scope: Construct, id: string) {
+    constructor(scope: Construct, id: string, envVariable: string) {
         super(scope, id);
         const authFunc = createLambda(this, {
             name: 'AuthorizationHandler',
             handlerPath: AuthorizationService.basicAuthorizer(),
+        }, {
+            soullnik: envVariable
         })
 
         this.authorizer = new TokenAuthorizer(this, 'reques-authorizer', {
@@ -24,11 +26,27 @@ export class GatewayStack extends Construct {
                 stageName: 'dev',
             },
             defaultCorsPreflightOptions: {
-                allowHeaders: Cors.DEFAULT_HEADERS,
+                allowHeaders: ['*'],
                 allowMethods: Cors.ALL_METHODS,
                 allowCredentials: true,
-                allowOrigins: Cors.ALL_ORIGINS,
+                allowOrigins: ['https://d3ieob9tiqtawy.cloudfront.net'],
             },
+        });
+
+        const responseHeaders = {
+            "Access-Control-Allow-Origin": "'https://d3ieob9tiqtawy.cloudfront.net'",
+            "Access-Control-Allow-Methods": "'OPTIONS,GET'",
+            "Access-Control-Allow-Headers": "'*'"
+        }
+
+        this.api.addGatewayResponse('GatewayResponseACCESS_DENIED', {
+            type: ResponseType.ACCESS_DENIED,
+            responseHeaders
+        });
+
+        this.api.addGatewayResponse('GatewayResponseUNAUTHORIZED', {
+            type: ResponseType.UNAUTHORIZED,
+            responseHeaders
         });
     }
 }

--- a/lib/import-service-stack.ts
+++ b/lib/import-service-stack.ts
@@ -7,9 +7,10 @@ import { RemovalPolicy } from "aws-cdk-lib";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { S3EventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Queue } from "aws-cdk-lib/aws-sqs";
+import { GatewayStack } from "./gateway-shop-stack";
 
 export class ImportServiceStack extends Construct {
-    constructor(scope: Construct, id: string, api: RestApi, catalogItemsQueue: Queue) {
+    constructor(scope: Construct, id: string, gateway: GatewayStack, catalogItemsQueue: Queue) {
         super(scope, id);
 
         const bucket = new Bucket(this, 'myBucket', {
@@ -72,6 +73,6 @@ export class ImportServiceStack extends Construct {
 
         importFileParser.addEventSource(s3PutEventSource);
 
-        api.root.addResource('import').addMethod('GET', new LambdaIntegration(importProductsFile))
+        gateway.api.root.addResource('import').addMethod('GET', new LambdaIntegration(importProductsFile), { authorizer: gateway.authorizer })
     }
 }

--- a/lib/products-service-stack.ts
+++ b/lib/products-service-stack.ts
@@ -7,9 +7,10 @@ import { createLambda } from "../src/utils/createLambda";
 import { ProductsService } from "../src/products";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { Topic } from "aws-cdk-lib/aws-sns";
+import { GatewayStack } from "./gateway-shop-stack";
 
 export class ProductsServiceStack extends Construct {
-    constructor(scope: Construct, id: string, api: RestApi, catalogItemsQueue: Queue, createProductTopic: Topic) {
+    constructor(scope: Construct, id: string, gateway: GatewayStack, catalogItemsQueue: Queue, createProductTopic: Topic) {
         super(scope, id);
 
         const productsTable = new Table(this, 'Products', {
@@ -64,7 +65,7 @@ export class ProductsServiceStack extends Construct {
         createProductTopic.grantPublish(catalogBatchProcess)
         catalogBatchProcess.addEventSource(new SqsEventSource(catalogItemsQueue, { batchSize: 5 }));
 
-        api.root.addResource('products').addMethod('GET', new LambdaIntegration(getProductList))
+        gateway.api.root.addResource('products').addMethod('GET', new LambdaIntegration(getProductList))
             .resource.addMethod('POST', new LambdaIntegration(postProduct))
             .resource.addResource('{product}').addMethod('GET', new LambdaIntegration(getProductById))
             .resource.addMethod('POST', new LambdaIntegration(postProduct));

--- a/src/authorization/handlers/basicAuthorizer.ts
+++ b/src/authorization/handlers/basicAuthorizer.ts
@@ -1,0 +1,32 @@
+import { APIGatewayAuthorizerResult, APIGatewayTokenAuthorizerEvent } from "aws-lambda"
+
+export const handler = async (
+    event: APIGatewayTokenAuthorizerEvent
+): Promise<APIGatewayAuthorizerResult> => {
+    console.log(event)
+    let token = event.authorizationToken
+
+    let effect = 'Deny'
+
+    if (token == "sGLzdRxvZmw0ZXs0UGFzcw==") {
+        effect = 'Allow'
+    } else {
+        effect = 'Deny'
+    }
+
+    let policy = {
+        "principalId": "user",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": effect,
+                    "Resource": event.methodArn
+                }
+            ]
+        }
+    }
+    return policy
+
+};

--- a/src/authorization/index.ts
+++ b/src/authorization/index.ts
@@ -1,0 +1,9 @@
+import path from "path"
+
+export class AuthorizationService {
+    static handlerName = 'handler'
+
+    static basicAuthorizer() {
+        return path.join(__dirname, 'handlers', 'basicAuthorizer.ts')
+    }
+}


### PR DESCRIPTION
1. [FE deploy](https://d3ieob9tiqtawy.cloudfront.net/)
3. [BE API](https://l8dkzcslhd.execute-api.eu-west-1.amazonaws.com/dev/)
4. [FE PR](https://github.com/Soullnik/nodejs-aws-shop-react/pull/5)


token: soullnik:TEST_PASSWORD / base64 c291bGxuaWs6VEVTVF9QQVNTV09SRA==


7. Completed tasks 100/100
- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct AWS CDK Stack
- [x] Import Service AWS CDK Stack has authorizer configuration for the importProductsFile lambda. Request to the  importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser
- [x] +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.
